### PR TITLE
build: Dockerfile + nginx config for self-hosted deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+node_modules
+dist
+.astro
+.vscode
+.idea
+*.log
+.DS_Store
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+RUN adduser -D -H -u 101 -s /sbin/nologin nginxuser 2>/dev/null || true
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://127.0.0.1/ || exit 1

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,46 @@
+map $sent_http_content_type $cache_control_strategy {
+    default                              "public, max-age=2592000";
+    ~^text/html                          "no-store, must-revalidate";
+    ~^text/css                           "public, max-age=31536000, immutable";
+    ~^application/javascript             "public, max-age=31536000, immutable";
+    ~^application/json                   "no-store, must-revalidate";
+    ~^image/                             "public, max-age=2592000";
+    ~^font/                              "public, max-age=31536000, immutable";
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+    add_header Cache-Control $cache_control_strategy always;
+
+    location / {
+        try_files $uri $uri/ $uri.html $uri/index.html =404;
+    }
+
+    location /_astro/ {
+        access_log off;
+        expires 1y;
+    }
+
+    location ~* \.(webp|avif|jpg|jpeg|png|gif|svg|ico|woff2?|ttf|otf|eot)$ {
+        access_log off;
+        expires 30d;
+    }
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss image/svg+xml;
+
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds multi-stage Dockerfile (`node:22-alpine` builder → `nginx:1.27-alpine` runtime, ~213 MB final image)
- Adds nginx.conf with Content-Type-driven cache policy + security headers
- Adds .dockerignore

## Verification (already done on townhouse-remote)
| Test | Result |
|---|---|
| 4 pages (`/`, `/about/`, `/portfolio/`, `/contact/`) return 200 | ✅ |
| Security headers (X-Frame, X-Content-Type, Referrer, Permissions) present on HTML | ✅ |
| HTML returns `Cache-Control: no-store, must-revalidate` | ✅ |
| CSS/JS returns `Cache-Control: public, max-age=31536000, immutable` | ✅ |
| 404 fallback works | ✅ |
| Docker healthcheck passes | ✅ |

## Deploy target
- Coolify on townhouse-remote (`100.66.207.21:8000`)
- Container port 80 → host port 9200 (reserved 9200-9299 for imagesbyolofsson.se stack)

## Follow-ups (separate PRs / config, not in this PR)
- Cloudflare A-record `imagesbyolofsson.se → 37.153.139.83` (proxied)
- Cleura SG opens port 9200 publicly
- Cloudflare Origin Rule rewrites :443 → :9200
- 301 redirects for legacy subdomains (site./portfolio./about./contact.)

## Co-authored
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>