### PR TITLE
fix: add astro.config.mjs with @tailwindcss/vite plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
 
 COPY . .
 RUN npm run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,4 @@
 @import "tailwindcss";
+
+@source "../**/*.{astro,html,js,jsx,ts,tsx,md,mdx,svelte,vue}";
+@source "../../public/**/*.html";


### PR DESCRIPTION
Tailwind 4 produced theme-only CSS without utility classes because Astro had no config wiring the @tailwindcss/vite plugin. Site rendered unstyled.

Verified locally: CSS grew from 21 KB to 36 KB, 23 utility-class definitions present.