### PR TITLE
fix(logo-pulse): dynamic viewport-anchored paths

### DIFF
--- a/src/components/WaveBackground.astro
+++ b/src/components/WaveBackground.astro
@@ -29,6 +29,12 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                 <stop offset="100%" style={`stop-color:${secondaryColor};stop-opacity:0`} />
             </linearGradient>
 
+            <linearGradient id="gradPurple" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" style="stop-color:#c026d3;stop-opacity:0" />
+                <stop offset="50%" style="stop-color:#c026d3;stop-opacity:0.45" />
+                <stop offset="100%" style="stop-color:#c026d3;stop-opacity:0" />
+            </linearGradient>
+
             <filter id="pulseGlowSoft" x="-100%" y="-100%" width="300%" height="300%">
                 <feGaussianBlur stdDeviation="22" />
             </filter>
@@ -65,6 +71,8 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
 
             <path id="thread1" d="M-1000 200 Q 400 400 900 200 T 2600 200" fill="none" stroke="url(#gradSec)" stroke-width="0.5" class="opacity-50" data-pulse-path="true" />
             <path id="thread2" d="M-1000 800 Q 600 600 1100 800 T 2600 800" fill="none" stroke="url(#gradSec)" stroke-width="0.8" class="opacity-60" data-pulse-path="true" />
+
+            <path id="threadPurple" d="M-1000 850 Q 400 600 900 850 T 2600 850" fill="none" stroke="url(#gradPurple)" stroke-width="0.7" class="opacity-55" data-pulse-path="true" data-purple-thread="true" />
         </g>
 
         <g id="box-trail-group"></g>
@@ -402,6 +410,134 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
         }
 
         const SPLIT_PROBABILITY = 0.55;
+        const LOGO_PROBABILITY = 0.20;
+
+        function isLogoTargetVisible(): HTMLElement | null {
+            const el = document.querySelector<HTMLElement>('[data-logo-target]');
+            if (!el) return null;
+            const rect = el.getBoundingClientRect();
+            if (rect.bottom < 0 || rect.top > window.innerHeight) return null;
+            if (rect.width < 50 || rect.height < 50) return null;
+            return el;
+        }
+
+        function runLogoPulse(durationMs: number) {
+            if (!blob1) return;
+            const logo = isLogoTargetVisible();
+            const purpleThread = document.getElementById('threadPurple') as SVGPathElement | null;
+            const greenThread = document.getElementById('wave1') as SVGPathElement | null;
+            if (!logo || !purpleThread || !greenThread) {
+                schedule();
+                return;
+            }
+            isPulsing = true;
+            updatePulseColors(false); // start cyan-themed (basis)
+
+            const rect = logo.getBoundingClientRect();
+            const logoLeftX = rect.left + 8;
+            const logoRightX = rect.right - 8;
+            const logoY = rect.top + rect.height / 2;
+
+            // PHASE 1: glide in på purple thread fram till logo-left
+            const purpleLen = purpleThread.getTotalLength();
+            // PHASE 2: in i logon — color shift
+            // PHASE 3: ut på wave1 (grön)
+            const greenLen = greenThread.getTotalLength();
+
+            const phase1Duration = durationMs * 0.35; // 35% glide in
+            const phase2Duration = durationMs * 0.30; // 30% inside logo
+            const phase3Duration = durationMs * 0.35; // 35% glide ut
+
+            const totalTime = phase1Duration + phase2Duration + phase3Duration;
+            const startTime = performance.now();
+
+            // Förbered purple gradient på pulse
+            const pinkColor = '#e879f9';
+            const greenColor = '#4fd1c5';
+
+            function setPulseTint(color: string) {
+                const haloStops = document.querySelectorAll('#pulseHaloGradient stop');
+                if (haloStops[0]) haloStops[0].setAttribute('style', `stop-color:${color};stop-opacity:0.85`);
+                if (haloStops[1]) haloStops[1].setAttribute('style', `stop-color:${color};stop-opacity:0.35`);
+                if (haloStops[2]) haloStops[2].setAttribute('style', `stop-color:${color};stop-opacity:0`);
+                const midStops = document.querySelectorAll('#pulseMidGradient stop');
+                if (midStops[0]) midStops[0].setAttribute('style', `stop-color:${color};stop-opacity:1`);
+                if (midStops[1]) midStops[1].setAttribute('style', `stop-color:${color};stop-opacity:0.5`);
+                if (midStops[2]) midStops[2].setAttribute('style', `stop-color:${color};stop-opacity:0`);
+            }
+
+            setPulseTint(pinkColor);
+            blob2 && blob2.setAttribute('opacity', '0');
+
+            // Find on purpleThread where it crosses logoLeftX (approx)
+            // Sample to find length when pt.x ~ logoLeftX
+            let purpleEntryLen = purpleLen;
+            for (let l = 0; l <= purpleLen; l += 4) {
+                const pt = purpleThread.getPointAtLength(l);
+                if (pt.x >= logoLeftX) { purpleEntryLen = l; break; }
+            }
+            let greenStartLen = 0;
+            for (let l = 0; l <= greenLen; l += 4) {
+                const pt = greenThread.getPointAtLength(l);
+                if (pt.x >= logoRightX) { greenStartLen = l; break; }
+            }
+            const greenEndLen = Math.min(greenStartLen + (greenLen - greenStartLen) * 0.55, greenLen);
+
+            function step(now: number) {
+                if (!blob1) return;
+                const elapsed = now - startTime;
+                const globalT = Math.min(elapsed / totalTime, 1);
+                const fade = fadeFactor(globalT);
+
+                if (elapsed <= phase1Duration) {
+                    // Glide in på purple thread fram till logo-left
+                    const t = elapsed / phase1Duration;
+                    const len = t * purpleEntryLen;
+                    const pt = purpleThread!.getPointAtLength(len);
+                    const angle = tangentAngle(purpleThread!, len, purpleLen);
+                    applyTransform(blob1!, pt.x, pt.y, angle);
+                    blob1!.setAttribute('opacity', String(fade));
+                } else if (elapsed <= phase1Duration + phase2Duration) {
+                    // INSIDE logo — pulse vid logo-center, ändra logo-färg
+                    const t = (elapsed - phase1Duration) / phase2Duration;
+                    // Pulse-position: glide från logoLeft till logoRight
+                    const cx = logoLeftX + (logoRightX - logoLeftX) * t;
+                    const cy = logoY;
+                    applyTransform(blob1!, cx, cy, 0);
+                    blob1!.setAttribute('opacity', String(fade * 0.6)); // dimmare i logo (logo-färg tar över visuellt)
+
+                    // Färg-shift: rosa första halvan, grön andra halvan
+                    if (t < 0.5) {
+                        logo!.setAttribute('data-logo-tint', 'pink');
+                        setPulseTint(pinkColor);
+                    } else {
+                        logo!.setAttribute('data-logo-tint', 'green');
+                        setPulseTint(greenColor);
+                    }
+                } else {
+                    // Glide ut på wave1 (grön)
+                    const t = Math.min((elapsed - phase1Duration - phase2Duration) / phase3Duration, 1);
+                    const len = greenStartLen + (greenEndLen - greenStartLen) * t;
+                    const pt = greenThread!.getPointAtLength(len);
+                    const angle = tangentAngle(greenThread!, len, greenLen);
+                    applyTransform(blob1!, pt.x, pt.y, angle);
+                    blob1!.setAttribute('opacity', String(fade));
+                    if (logo!.getAttribute('data-logo-tint')) {
+                        // Fade tillbaka till basis
+                        logo!.removeAttribute('data-logo-tint');
+                    }
+                }
+
+                if (elapsed < totalTime && globalT < 1) {
+                    requestAnimationFrame(step);
+                } else {
+                    blob1!.setAttribute('opacity', '0');
+                    logo!.removeAttribute('data-logo-tint');
+                    isPulsing = false;
+                }
+            }
+            requestAnimationFrame(step);
+        }
 
         function pickAndPulse() {
             if (isPulsing) {
@@ -412,6 +548,15 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                 schedule();
                 return;
             }
+
+            // 20% chans för logo-pulse OM logo är synlig
+            const wantLogo = Math.random() < LOGO_PROBABILITY;
+            if (wantLogo && isLogoTargetVisible()) {
+                runLogoPulse(14000 + Math.random() * 4000);
+                schedule();
+                return;
+            }
+
             const boxes = refreshBoxes();
             const intersecting: SVGPathElement[] = [];
             const nonIntersecting: SVGPathElement[] = [];

--- a/src/components/WaveBackground.astro
+++ b/src/components/WaveBackground.astro
@@ -229,46 +229,45 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
             exit: { x: number; y: number },
             half: 'top' | 'bottom'
         ): SVGPathElement {
-            // Goal: smooth path from entry-point → out to box-edge → around half → back from box-edge → exit-point.
-            // We route via the actual box corners + halfway top or bottom of the box.
+            // Path goes: entry → mjuk kurva mot box-kant (top eller bottom) → traverserar horisontellt över box-kanten → mjuk kurva från box-kant till exit-punkt
+            // KRITISKT: pathen ska BARA röra sig framåt (entry.x → exit.x), aldrig vända tillbaka
             const xL = box.left, xR = box.right, yT = box.top, yB = box.bottom, r = box.r;
-            const yMid = box.cy;
 
-            // Tangent-out from entry: smoothly leave the thread and head toward box-edge near top-or-bottom
-            // First waypoint on box-edge — closer to entry's y but rounded into the top/bottom corner
-            const targetTopY = yT;
-            const targetBotY = yB;
-            const apexY = half === 'top' ? targetTopY : targetBotY;
+            // För att undvika "tillbaka-rörelse" när entry/exit ligger UTANFÖR boxens X-range:
+            // Använd entry.x och exit.x som start/end-punkter på den horisontella delen,
+            // clampad till box-kanten med hörn-radius
+            const startX = Math.max(xL + r, Math.min(xR - r, entry.x));
+            const endX = Math.max(xL + r, Math.min(xR - r, exit.x));
 
-            // Two control points to bezier from entry into the corner curve
-            const transitionDist = 24;
-            const cp1x = entry.x + (half === 'top' ? -10 : -10);
-            const cp1y = entry.y + (half === 'top' ? -transitionDist : transitionDist);
-            const cp2x = xL + r;
-            const cp2y = apexY;
+            // Top/bottom Y-koordinat för traversal
+            const traverseY = half === 'top' ? yT : yB;
 
-            // After top/bottom traversal, exit via similar curve back to exit-point
-            const cp3x = xR - r;
-            const cp3y = apexY;
-            const cp4x = exit.x + (half === 'top' ? 10 : 10);
-            const cp4y = exit.y + (half === 'top' ? -transitionDist : transitionDist);
+            // Distans från entry/exit till traverseY (för smooth bezier-overgång)
+            const entryToTraverseY = Math.abs(entry.y - traverseY);
+            const exitToTraverseY = Math.abs(exit.y - traverseY);
 
-            let d: string;
-            if (half === 'top') {
-                d = [
-                    `M ${entry.x} ${entry.y}`,
-                    `C ${cp1x} ${cp1y}, ${cp2x} ${cp2y - r}, ${xL + r} ${yT}`,
-                    `H ${xR - r}`,
-                    `C ${cp3x} ${cp3y - r}, ${cp4x} ${cp4y}, ${exit.x} ${exit.y}`,
-                ].join(' ');
-            } else {
-                d = [
-                    `M ${entry.x} ${entry.y}`,
-                    `C ${cp1x} ${cp1y}, ${cp2x} ${cp2y + r}, ${xL + r} ${yB}`,
-                    `H ${xR - r}`,
-                    `C ${cp3x} ${cp3y + r}, ${cp4x} ${cp4y}, ${exit.x} ${exit.y}`,
-                ].join(' ');
-            }
+            // Kontrollpunkter för Bezier — låt dem peka i rätt riktning (top eller bottom)
+            // cp1: nära entry, dragen mot traverseY
+            const cp1x = entry.x;
+            const cp1y = entry.y + (half === 'top' ? -entryToTraverseY * 0.5 : entryToTraverseY * 0.5);
+            // cp2: vid startX, redan på traverseY-nivå
+            const cp2x = startX;
+            const cp2y = traverseY;
+
+            // cp3: vid endX, fortfarande på traverseY
+            const cp3x = endX;
+            const cp3y = traverseY;
+            // cp4: nära exit, dragen från traverseY
+            const cp4x = exit.x;
+            const cp4y = exit.y + (half === 'top' ? -exitToTraverseY * 0.5 : exitToTraverseY * 0.5);
+
+            const d = [
+                `M ${entry.x} ${entry.y}`,
+                `C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${startX} ${traverseY}`,
+                `L ${endX} ${traverseY}`,
+                `C ${cp3x} ${cp3y}, ${cp4x} ${cp4y}, ${exit.x} ${exit.y}`,
+            ].join(' ');
+
             const p = document.createElementNS(NS, 'path');
             p.setAttribute('d', d);
             p.setAttribute('fill', 'none');
@@ -325,6 +324,8 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
             let topPath: SVGPathElement | null = null;
             let bottomPath: SVGPathElement | null = null;
             let phase2Duration = 0;
+            // För TIME-SYNCED meeting: båda blobs animeras med samma t (0→1), olika path-längder = olika faktisk hastighet
+            // Phase2-duration baseras på genomsnittlig path-längd så hastighets-skillnaden hålls liten
             if (hit) {
                 const entryPt = { x: hit.entryX, y: hit.entryY };
                 const exitPt = { x: hit.exitX, y: hit.exitY };
@@ -334,7 +335,9 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                 boxGroup.appendChild(bottomPath);
                 const topLen = topPath.getTotalLength();
                 const bottomLen = bottomPath.getTotalLength();
-                phase2Duration = Math.max(topLen, bottomLen) / velocity;
+                // Genomsnittlig längd för fart-beräkning (så snabba/långsamma delas jämnt)
+                const avgLen = (topLen + bottomLen) / 2;
+                phase2Duration = avgLen / velocity;
             }
 
             const phase3Duration = hit ? (total - exitLen) / velocity : 0;
@@ -359,8 +362,11 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                     if (topPath && bottomPath) {
                         const topLen = topPath.getTotalLength();
                         const bottomLen = bottomPath.getTotalLength();
-                        const tDist = Math.min(inPhase2 * velocity, topLen);
-                        const bDist = Math.min(inPhase2 * velocity, bottomLen);
+                        // TIME-SYNCED: båda blobs har samma t (0→1) inom phase2 → möts garanterat samtidigt
+                        // Hastighets-skillnad uppstår automatiskt om topLen ≠ bottomLen
+                        const phase2T = Math.min(inPhase2 / phase2Duration, 1);
+                        const tDist = phase2T * topLen;
+                        const bDist = phase2T * bottomLen;
 
                         const tp = topPath.getPointAtLength(tDist);
                         const ta = tangentAngle(topPath, tDist, topLen);

--- a/src/components/WaveBackground.astro
+++ b/src/components/WaveBackground.astro
@@ -410,7 +410,7 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
         }
 
         const SPLIT_PROBABILITY = 0.55;
-        const LOGO_PROBABILITY = 0.20;
+        const LOGO_PROBABILITY = 0.50;
 
         function isLogoTargetVisible(): HTMLElement | null {
             const el = document.querySelector<HTMLElement>('[data-logo-target]');
@@ -422,36 +422,54 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
         }
 
         function runLogoPulse(durationMs: number) {
-            if (!blob1) return;
+            if (!blob1 || !boxGroup) return;
             const logo = isLogoTargetVisible();
-            const purpleThread = document.getElementById('threadPurple') as SVGPathElement | null;
-            const greenThread = document.getElementById('wave1') as SVGPathElement | null;
-            if (!logo || !purpleThread || !greenThread) {
+            if (!logo) {
                 schedule();
                 return;
             }
             isPulsing = true;
-            updatePulseColors(false); // start cyan-themed (basis)
+            updatePulseColors(false);
 
             const rect = logo.getBoundingClientRect();
+            const vw = window.innerWidth;
             const logoLeftX = rect.left + 8;
             const logoRightX = rect.right - 8;
             const logoY = rect.top + rect.height / 2;
 
-            // PHASE 1: glide in på purple thread fram till logo-left
-            const purpleLen = purpleThread.getTotalLength();
-            // PHASE 2: in i logon — color shift
-            // PHASE 3: ut på wave1 (grön)
-            const greenLen = greenThread.getTotalLength();
+            // DYNAMIC PATHS — bygg paths som GARANTERAT passar logo-positionen.
+            // Pulsen kommer från vänster off-screen, lite under logon, kurvar UPP in i logo-left,
+            // glider genom logo, kurvar UT mot höger off-screen, lite över logon
+            const offLeft = -100;
+            const offRight = vw + 100;
+            const dipY = logoY + rect.height * 0.7;  // entry kommer underifrån vänster
+            const riseY = logoY - rect.height * 0.7; // exit lämnar uppåt höger
 
-            const phase1Duration = durationMs * 0.35; // 35% glide in
-            const phase2Duration = durationMs * 0.30; // 30% inside logo
-            const phase3Duration = durationMs * 0.35; // 35% glide ut
+            const NS_local = 'http://www.w3.org/2000/svg';
+            // Entry path (lila): från off-screen vänster (dipY) kurvar upp till logo-left
+            const entryPath = document.createElementNS(NS_local, 'path');
+            entryPath.setAttribute('d', `M ${offLeft} ${dipY} C ${logoLeftX - 200} ${dipY}, ${logoLeftX - 80} ${logoY}, ${logoLeftX} ${logoY}`);
+            entryPath.setAttribute('fill', 'none');
+            entryPath.setAttribute('stroke', 'transparent');
+            boxGroup.appendChild(entryPath);
+
+            // Exit path (grön): från logo-right kurvar upp till off-screen höger (riseY)
+            const exitPath = document.createElementNS(NS_local, 'path');
+            exitPath.setAttribute('d', `M ${logoRightX} ${logoY} C ${logoRightX + 80} ${logoY}, ${logoRightX + 200} ${riseY}, ${offRight} ${riseY}`);
+            exitPath.setAttribute('fill', 'none');
+            exitPath.setAttribute('stroke', 'transparent');
+            boxGroup.appendChild(exitPath);
+
+            const entryLen = entryPath.getTotalLength();
+            const exitLen = exitPath.getTotalLength();
+
+            const phase1Duration = durationMs * 0.35;
+            const phase2Duration = durationMs * 0.30;
+            const phase3Duration = durationMs * 0.35;
 
             const totalTime = phase1Duration + phase2Duration + phase3Duration;
             const startTime = performance.now();
 
-            // Förbered purple gradient på pulse
             const pinkColor = '#e879f9';
             const greenColor = '#4fd1c5';
 
@@ -469,20 +487,6 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
             setPulseTint(pinkColor);
             blob2 && blob2.setAttribute('opacity', '0');
 
-            // Find on purpleThread where it crosses logoLeftX (approx)
-            // Sample to find length when pt.x ~ logoLeftX
-            let purpleEntryLen = purpleLen;
-            for (let l = 0; l <= purpleLen; l += 4) {
-                const pt = purpleThread.getPointAtLength(l);
-                if (pt.x >= logoLeftX) { purpleEntryLen = l; break; }
-            }
-            let greenStartLen = 0;
-            for (let l = 0; l <= greenLen; l += 4) {
-                const pt = greenThread.getPointAtLength(l);
-                if (pt.x >= logoRightX) { greenStartLen = l; break; }
-            }
-            const greenEndLen = Math.min(greenStartLen + (greenLen - greenStartLen) * 0.55, greenLen);
-
             function step(now: number) {
                 if (!blob1) return;
                 const elapsed = now - startTime;
@@ -490,11 +494,11 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                 const fade = fadeFactor(globalT);
 
                 if (elapsed <= phase1Duration) {
-                    // Glide in på purple thread fram till logo-left
+                    // Glide in på entry-path (lila)
                     const t = elapsed / phase1Duration;
-                    const len = t * purpleEntryLen;
-                    const pt = purpleThread!.getPointAtLength(len);
-                    const angle = tangentAngle(purpleThread!, len, purpleLen);
+                    const len = t * entryLen;
+                    const pt = entryPath.getPointAtLength(len);
+                    const angle = tangentAngle(entryPath, len, entryLen);
                     applyTransform(blob1!, pt.x, pt.y, angle);
                     blob1!.setAttribute('opacity', String(fade));
                 } else if (elapsed <= phase1Duration + phase2Duration) {
@@ -515,15 +519,14 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                         setPulseTint(greenColor);
                     }
                 } else {
-                    // Glide ut på wave1 (grön)
+                    // Glide ut på exit-path (grön)
                     const t = Math.min((elapsed - phase1Duration - phase2Duration) / phase3Duration, 1);
-                    const len = greenStartLen + (greenEndLen - greenStartLen) * t;
-                    const pt = greenThread!.getPointAtLength(len);
-                    const angle = tangentAngle(greenThread!, len, greenLen);
+                    const len = t * exitLen;
+                    const pt = exitPath.getPointAtLength(len);
+                    const angle = tangentAngle(exitPath, len, exitLen);
                     applyTransform(blob1!, pt.x, pt.y, angle);
                     blob1!.setAttribute('opacity', String(fade));
                     if (logo!.getAttribute('data-logo-tint')) {
-                        // Fade tillbaka till basis
                         logo!.removeAttribute('data-logo-tint');
                     }
                 }
@@ -533,6 +536,9 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
                 } else {
                     blob1!.setAttribute('opacity', '0');
                     logo!.removeAttribute('data-logo-tint');
+                    // Cleanup dynamic paths
+                    if (entryPath.parentNode) entryPath.parentNode.removeChild(entryPath);
+                    if (exitPath.parentNode) exitPath.parentNode.removeChild(exitPath);
                     isPulsing = false;
                 }
             }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,8 +14,8 @@ import WaveBackground from '../components/WaveBackground.astro';
   <div id="hero-text" class="fixed top-0 left-0 w-full h-screen flex flex-col items-center justify-center z-10 pointer-events-none opacity-0 transition-all duration-700 ease-in-out">
     
     <div class="text-center animated-text-container relative">
-      
-      <div id="text-wrapper" class="inline-block relative p-6 transition-all duration-500">
+
+      <div id="text-wrapper" data-logo-target class="inline-block relative p-6 transition-all duration-500">
         
         <h1 class="text-5xl md:text-8xl font-black text-white tracking-tighter leading-none drop-shadow-[0_0_10px_rgba(34,211,238,0.4)] relative z-10">
             IMAGES BY <br/> OLOFSSON
@@ -108,12 +108,40 @@ import WaveBackground from '../components/WaveBackground.astro';
     }
     .smoky-path {
         animation: drawPath 6s cubic-bezier(0.4, 0, 0.2, 1) infinite, smokeShift 10s ease-in-out infinite alternate;
+        transition: stroke 0.8s ease, filter 0.8s ease;
     }
     @keyframes smokeShift {
         0% { stroke: #374151; }
         33% { stroke: #4b5563; }
         66% { stroke: #334155; }
         100% { stroke: #1f2937; }
+    }
+
+    /* Logo-pulse: när data-attribut sätts på text-wrapper, override:a stroke + drop-shadow */
+    #text-wrapper[data-logo-tint="pink"] ~ * .smoky-path,
+    #text-wrapper[data-logo-tint="pink"] .smoky-path {
+        animation: none !important;
+        stroke: #e879f9 !important;
+        opacity: 0.95 !important;
+        filter: url(#fog-filter) drop-shadow(0 0 12px rgba(232,121,249,0.7));
+    }
+    #text-wrapper[data-logo-tint="green"] ~ * .smoky-path,
+    #text-wrapper[data-logo-tint="green"] .smoky-path {
+        animation: none !important;
+        stroke: #4fd1c5 !important;
+        opacity: 0.95 !important;
+        filter: url(#fog-filter) drop-shadow(0 0 12px rgba(79,209,197,0.7));
+    }
+    #text-wrapper[data-logo-tint="pink"] h1 {
+        text-shadow: 0 0 25px rgba(232,121,249,0.85), 0 0 50px rgba(232,121,249,0.55);
+        transition: text-shadow 0.6s ease;
+    }
+    #text-wrapper[data-logo-tint="green"] h1 {
+        text-shadow: 0 0 25px rgba(79,209,197,0.85), 0 0 50px rgba(79,209,197,0.55);
+        transition: text-shadow 0.6s ease;
+    }
+    #text-wrapper h1 {
+        transition: text-shadow 0.8s ease;
     }
 
     /* --- BRACKETS (Hörnen) --- */


### PR DESCRIPTION
Build dynamic Bezier paths anchored to logo's getBoundingClientRect position instead of relying on fixed SVG-coords for wave1/threadPurple (which are off-screen on ultrawide viewports due to parallax-translateX).