### PR TITLE
fix(logo-threads): pass exactly through logo-center

### DIFF
--- a/src/components/WaveBackground.astro
+++ b/src/components/WaveBackground.astro
@@ -72,8 +72,8 @@ const pulseCore = theme === 'purple' ? '#fdf4ff' : '#f0fdfa';
             <path id="thread1" d="M-1000 200 Q 400 400 900 200 T 2600 200" fill="none" stroke="url(#gradSec)" stroke-width="0.5" class="opacity-50" data-pulse-path="true" />
             <path id="thread2" d="M-1000 800 Q 600 600 1100 800 T 2600 800" fill="none" stroke="url(#gradSec)" stroke-width="0.8" class="opacity-60" data-pulse-path="true" />
 
-            <path id="threadLogoIn" d="M-1000 500 Q 200 350 850 287 T 2600 200" fill="none" stroke="url(#gradPurple)" stroke-width="0.7" class="opacity-55" />
-            <path id="threadLogoOut" d="M-1000 350 Q 400 200 850 287 T 2600 500" fill="none" stroke="url(#gradMain)" stroke-width="0.7" class="opacity-50" />
+            <path id="threadLogoIn" d="M-1000 600 C -300 600, 400 287, 900 287 S 1900 287, 2600 100" fill="none" stroke="url(#gradPurple)" stroke-width="0.7" class="opacity-55" />
+            <path id="threadLogoOut" d="M-1000 100 C -300 100, 400 287, 900 287 S 1900 287, 2600 600" fill="none" stroke="url(#gradMain)" stroke-width="0.7" class="opacity-50" />
         </g>
 
         <g id="box-trail-group"></g>


### PR DESCRIPTION
Cubic Bezier locks Y=287 across logo X-range.